### PR TITLE
Fix find bug bugs 

### DIFF
--- a/src/main/java/NotifyClientTask.java
+++ b/src/main/java/NotifyClientTask.java
@@ -56,9 +56,9 @@ public class NotifyClientTask extends Task {
         LinkedList<DatagramPacket> packets = new LinkedList<DatagramPacket>();
 
         Map<String, Long> packetInfo = new HashMap<String, Long>();
-        for (File file : filetimes.keySet()) {
-            Long time = filetimes.get(file);
-            String host = getFullHostname(file);
+        for (Map.Entry<File, Long> file : filetimes.entrySet()) {
+            Long time = file.getValue();
+            String host = getFullHostname(file.getKey());
 
             if (host != null) {
                 Long oldTime = packetInfo.get(host);

--- a/src/main/java/ProfileInfoTask.java
+++ b/src/main/java/ProfileInfoTask.java
@@ -72,14 +72,18 @@ public class ProfileInfoTask extends Task implements java.io.FileFilter {
 				"<?xml version='1.0' encoding='utf-8'?>\n");
 		contents.append("<profiles>\n");
 		File[] files = outputdir.listFiles(this);
-		for (File file : files) {
-			long mtime = file.lastModified();
-			contents.append("<profile mtime='");
-			contents.append(mtime);
-			contents.append("'>");
-			contents.append(file.getName());
-			contents.append("</profile>\n");
-		}
+                if (files != null) {
+                    for (File file : files) {
+                        long mtime = file.lastModified();
+                        contents.append("<profile mtime='");
+                        contents.append(mtime);
+                        contents.append("'>");
+                        contents.append(file.getName());
+                        contents.append("</profile>\n");
+                    }
+                } else {
+                    throw new BuildException("Files Array is Null");
+                }
 		contents.append("</profiles>\n");
 
 		// Create the output file.

--- a/src/main/java/ProfileInfoTask.java
+++ b/src/main/java/ProfileInfoTask.java
@@ -41,15 +41,14 @@ public class ProfileInfoTask extends Task implements java.io.FileFilter {
 	@Override
 	public void execute() throws BuildException {
 		// Sanity checks on the output directory.
-		if (profilesDirName == null) {
-			throw new BuildException("profilesDirName not specified");
-		}
-		if (profilesDirName.length() == 0) {
-			if ( debugTask ) {
-				System.out.println("profilesDirName parameters is an empty string: do nothing.");
-			}
-			return;
-		}
+            if (profilesDirName == null) {
+                throw new BuildException("profilesDirName not specified");
+            } else if (profilesDirName.length() == 0) {
+                if (debugTask) {
+                    System.out.println("profilesDirName parameters is an empty string: do nothing.");
+                }
+                return;
+            }
                 if ( debugTask ) {
 			System.out.println("Checking if profilesDirName ("+profilesDirName+") is a valid directory");
 		}

--- a/src/main/java/ProfileInfoTask.java
+++ b/src/main/java/ProfileInfoTask.java
@@ -58,7 +58,7 @@ public class ProfileInfoTask extends Task implements java.io.FileFilter {
 			throw new BuildException("outputdir (" + outputdir
 					+ ") does not exist");
 		}
-		if (!outputdir.isDirectory()) {                   
+		if (!outputdir.isDirectory()) {
 			throw new BuildException("outputdir (" + outputdir
 					+ ") is not a directory");
 		}

--- a/src/main/java/ProfileInfoTask.java
+++ b/src/main/java/ProfileInfoTask.java
@@ -41,14 +41,15 @@ public class ProfileInfoTask extends Task implements java.io.FileFilter {
 	@Override
 	public void execute() throws BuildException {
 		// Sanity checks on the output directory.
-            if (profilesDirName == null) {
-                throw new BuildException("profilesDirName not specified");
-            } else if (profilesDirName.length() == 0) {
-                if (debugTask) {
-                    System.out.println("profilesDirName parameters is an empty string: do nothing.");
-                }
-                return;
-            }
+		if (profilesDirName == null) {
+			throw new BuildException("profilesDirName not specified");
+		}
+		if (profilesDirName.length() == 0) {
+			if ( debugTask ) {
+				System.out.println("profilesDirName parameters is an empty string: do nothing.");
+			}
+			return;
+		}
                 if ( debugTask ) {
 			System.out.println("Checking if profilesDirName ("+profilesDirName+") is a valid directory");
 		}
@@ -57,7 +58,7 @@ public class ProfileInfoTask extends Task implements java.io.FileFilter {
 			throw new BuildException("outputdir (" + outputdir
 					+ ") does not exist");
 		}
-		if (!outputdir.isDirectory()) {
+		if (!outputdir.isDirectory()) {                   
 			throw new BuildException("outputdir (" + outputdir
 					+ ") is not a directory");
 		}

--- a/src/main/java/VOConfigTask.java
+++ b/src/main/java/VOConfigTask.java
@@ -514,7 +514,7 @@ public class VOConfigTask extends Task {
                             vomsServers.put(VOMSServerKey,vomsServer);
                         }
                         vomsEndpoint.setServer(vomsServers.get(VOMSServerKey));
-                        //vomsEndpoint.setEndpoint("vomss://" + vomsServer.getHost()bae + ":" + Integer.toString(vomsServer.getPort()) + "/voms/" + voConfig.getName() + "?/" + voConfig.getName());
+                        //vomsEndpoint.setEndpoint("vomss://" + vomsServer.getHost() + ":" + Integer.toString(vomsServer.getPort()) + "/voms/" + voConfig.getName() + "?/" + voConfig.getName());
                         voConfig.addVomsEndpoint(vomsEndpoint);
                     }
                 } else {
@@ -765,7 +765,7 @@ public class VOConfigTask extends Task {
 
     // Class representing a VOMS server endpoint (used by a specific V0)
     
-    private class VOMSEndpoint {
+    private static class VOMSEndpoint {
         protected VOMSServer server = null;
         protected int port;
         protected String endpoint = null;
@@ -1058,7 +1058,7 @@ if ( (entrySuffix.length() > 0) ) {
     
     // Class to represent a VOMS server certificate
     
-    private class VOMSServerCertificate {
+    private static class VOMSServerCertificate {
         // An empty string for base64 means that the certificate is not valid and must be ignored
         private String base64 = null;
         private BigInteger serial = null;
@@ -1330,7 +1330,7 @@ if ( (entrySuffix.length() > 0) ) {
     
     // Class to keep track of VOs using the same accounting prefix
     
-    private class AccountPrefixConflict {
+    private static class AccountPrefixConflict {
         protected LinkedList<String> vos = new LinkedList<String>();
         
         // Methods

--- a/src/main/java/VOConfigTask.java
+++ b/src/main/java/VOConfigTask.java
@@ -36,6 +36,7 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.nio.charset.Charset;
+import java.util.Map;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
@@ -783,8 +784,8 @@ public class VOConfigTask extends Task {
                 if ( getPilotRoleFQAN() != null ) {
                     fqanList.get(getPilotRoleFQAN()).writeTemplate(template,this);
                 }
-                for (String key : fqanList.keySet()) {
-                    VOMSFqan fqan = fqanList.get(key);
+                for (Map.Entry<String,VOMSFqan > entry: fqanList.entrySet()) {
+                    VOMSFqan fqan = entry.getValue();
                     if ( !fqan.isPilotRole() ) {
                         fqan.writeTemplate(template,this);
                     }

--- a/src/main/java/VOConfigTask.java
+++ b/src/main/java/VOConfigTask.java
@@ -974,12 +974,12 @@ public class VOConfigTask extends Task {
                             //    System.err.println("Certificate delimiter="+delimiter);
                             //}
                             templateScanner.useDelimiter(delimiter+"\\s*;*");
-                            String certValue = templateScanner.next();
-                            if ( certValue != null ) {
+                            if (templateScanner.hasNext()) {
+                                String certValue = templateScanner.next();
                                 try {
                                     existingCerts.put(certType, new VOMSServerCertificate(certValue));
                                 } catch (CertificateException e) {
-                                        System.out.println("    Existing certificate ('"+certType+"') no longer valid, ignoring it.");
+                                    System.out.println("    Existing certificate ('" + certType + "') no longer valid, ignoring it.");
                                 }
                             } else {
                                 System.out.println("    WARNING: invalid format of certificate declaration ('"+certType+"') in existing template");

--- a/src/main/java/VOConfigTask.java
+++ b/src/main/java/VOConfigTask.java
@@ -74,9 +74,6 @@ public class VOConfigTask extends Task {
     /* Namespace (relative directory) to use for templates containing VOMS server certificates */
     protected String certsTplNS = null;
 
-    /* Namespace (relative directory) to use for templates containing VO site-specific params */
-    protected String siteParamsTplNS = null;
-
     /* URI for VO ID card source */
     protected String voIdCardsUri = null;
 
@@ -88,17 +85,6 @@ public class VOConfigTask extends Task {
 
     /* Name of the template containing the list of all defined VOs */
     protected String vomsServerDNsTemplate = "voms_dn_list";
-
-    /* Algorithm used to generate account suffix.
-     * The original one was very bad at ensuring suffix uniqueness, requiring several retries to get
-     * a unique suffix and thus making the actual suffix dependent on the FQAN order which historicall was alphabetical.
-     * With the new algorithm, there is a very small chance of suffix conflict and the FQAN order in the VO card is
-     * maintained to limit side effect of generation retries (with the assumption that new FQAN are added at the end of
-     * the list in the VO ID card.
-     * Default is to use the new algorithm but the option must be passed explicitly to preserve account
-     * backward compatibility (in term of account names and uids).
-     */
-    protected boolean legacySuffixAlgorithm = false;
 
     /* Control printing of debugging messages in this task */
     protected boolean debugTask = false;
@@ -194,30 +180,6 @@ public class VOConfigTask extends Task {
     public void setcertsTplNS(String certsTplNS) {
         this.certsTplNS = certsTplNS;
     }
-
-    /**
-     * Set the namespace (relative directory) for site-specific templates related to VO cnfiguration.
-     * 
-     * @param siteParamsTplNS
-     *            String containing a template form of the path to the
-     *            customization directory
-     * 
-     */
-    public void setsiteParamsTplNS(String siteParamsTplNS) {
-        this.siteParamsTplNS = siteParamsTplNS;
-    }
-
-    /**
-     * Set the version of the algorithm to use for generating account suffix.
-     * 
-     * @param legacySuffixAlgorithm
-     *            if true, used the legacy algorithm for backward compatibility.
-     * 
-     */
-    public void setlegacySuffixAlgorithm(boolean legacySuffixAlgorithm) {
-        this.legacySuffixAlgorithm = legacySuffixAlgorithm;
-    }
-
 
     // Possible FQAN for a Software Manager
     static final private String softwareManagerSuffix = "s";
@@ -552,7 +514,7 @@ public class VOConfigTask extends Task {
                             vomsServers.put(VOMSServerKey,vomsServer);
                         }
                         vomsEndpoint.setServer(vomsServers.get(VOMSServerKey));
-                        //vomsEndpoint.setEndpoint("vomss://" + vomsServer.getHost() + ":" + Integer.toString(vomsServer.getPort()) + "/voms/" + voConfig.getName() + "?/" + voConfig.getName());
+                        //vomsEndpoint.setEndpoint("vomss://" + vomsServer.getHost()bae + ":" + Integer.toString(vomsServer.getPort()) + "/voms/" + voConfig.getName() + "?/" + voConfig.getName());
                         voConfig.addVomsEndpoint(vomsEndpoint);
                     }
                 } else {

--- a/src/main/java/VOConfigTask.java
+++ b/src/main/java/VOConfigTask.java
@@ -557,7 +557,6 @@ public class VOConfigTask extends Task {
                     }
                 } else {
                     if ( qName.equals("hostname") ) {
-                        String hostname = data.trim();
                         vomsServer.setHost(data.trim());
                     } else if ( qName.equals("X509PublicKey") ) {
                         vomsServer.setCert(data.trim());


### PR DESCRIPTION
Fixes the following issues from #14

<table border="0" class="bodyTable">
<div class="section">
<h3><a name="org.quattor.ant.NotifyClientTask"></a>org.quattor.ant.NotifyClientTask</h3>
<table border="0" class="bodyTable">
<tr class="a">
<th>Bug</th>
<th>Category</th>
<th>Details</th>
<th>Line</th>
<th>Priority</th></tr>
<tr class="b">
<td>org.quattor.ant.NotifyClientTask.execute() makes inefficient use of keySet iterator instead of entrySet iterator</td>
<td>PERFORMANCE</td>
<td><a class="externalLink" href="http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR">WMI_WRONG_MAP_ITERATOR</a></td>
<td>69</td>
<td>Medium</td></tr></table></div><a name="org.quattor.ant.ProfileInfoTask"></a>
<b>Replaced keySet Iteration with EntrySet Iteration, which is more efficient.</b>
<a name="org.quattor.ant.VOConfigTask"></a>
<div class="section">
<h3><a name="org.quattor.ant.VOConfigTask"></a>org.quattor.ant.VOConfigTask</h3>
<table border="0" class="bodyTable">
<tr class="a">
<th>Bug</th>
<th>Category</th>
<th>Details</th>
<th>Line</th>
<th>Priority</th></tr>
<tr class="b">
<td>Unread public/protected field: org.quattor.ant.VOConfigTask.legacySuffixAlgorithm</td>
<td>STYLE</td>
<td><a class="externalLink" href="http://findbugs.sourceforge.net/bugDescriptions.html#URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD">URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD</a></td>
<td>109</td>
<td>Medium</td></tr>
<tr class="a">
<td>Unread public/protected field: org.quattor.ant.VOConfigTask.siteParamsTplNS</td>
<td>STYLE</td>
<td><a class="externalLink" href="http://findbugs.sourceforge.net/bugDescriptions.html#URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD">URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD</a></td>
<td>86</td>
<td>Medium</td></tr></table></div>
<b>Removed unused fields and methods that were made obselete by past commits but were not removed. Corresponding commit for 1 issue: <a href = "https://github.com/quattor/scdb-ant-utils/commit/3e1936cd0277f32517ec558fb45844acb9484d9a">https://github.com/quattor/scdb-ant-utils/commit/3e1936cd0277f32517ec558fb45844acb9484d9a</a></b>
<a name="org.quattor.ant.VOConfigTaskVOCardHandler"></a>
<div class="section">
<h3><a name="org.quattor.ant.VOConfigTaskVOCardHandler"></a>org.quattor.ant.VOConfigTask$VOCardHandler</h3>
<table border="0" class="bodyTable">
<tr class="b">
<th>Bug</th>
<th>Category</th>
<th>Details</th>
<th>Line</th>
<th>Priority</th></tr>
<tr class="a">
<td>Dead store to hostname in org.quattor.ant.VOConfigTask$VOCardHandler.endElement(String, String, String)</td>
<td>STYLE</td>
<td><a class="externalLink" href="http://findbugs.sourceforge.net/bugDescriptions.html#DLS_DEAD_LOCAL_STORE">DLS_DEAD_LOCAL_STORE</a></td>
<td>568</td>
<td>Medium</td></tr></table></div>
<b>Removed assignment of variable that is never used.</b><a name="org.quattor.ant.VOConfigTaskVOConfig"></a>
<div class="section">
<h3><a name="org.quattor.ant.VOConfigTaskVOConfig"></a>org.quattor.ant.VOConfigTask$VOConfig</h3>
<table border="0" class="bodyTable">
<tr class="b">
<th>Bug</th>
<th>Category</th>
<th>Details</th>
<th>Line</th>
<th>Priority</th></tr>
<tr class="a">
<td>org.quattor.ant.VOConfigTask$VOConfig.writeVOTemplate(String) makes inefficient use of keySet iterator instead of entrySet iterator</td>
<td>PERFORMANCE</td>
<td><a class="externalLink" href="http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR">WMI_WRONG_MAP_ITERATOR</a></td>
<td>796</td>
<td>Medium</td></tr></table></div><b>Replaced keySet Iteration with EntrySet Iteration, which is more efficient.</b><a name="org.quattor.ant.VOConfigTaskVOMSServer"></a>
<div class="section">
<h3><a name="org.quattor.ant.VOConfigTaskVOMSServer"></a>org.quattor.ant.VOConfigTask$VOMSServer</h3>
<table border="0" class="bodyTable">
<tr class="b">
<th>Bug</th>
<th>Category</th>
<th>Details</th>
<th>Line</th>
<th>Priority</th></tr>
<tr class="a">
<td>Redundant nullcheck of certValue, which is known to be non-null in org.quattor.ant.VOConfigTask$VOMSServer.setOldCert(String)</td>
<td>STYLE</td>
<td><a class="externalLink" href="http://findbugs.sourceforge.net/bugDescriptions.html#RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE">RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE</a></td>
<td>987</td>
<td>Medium</td></tr></table></div><b>Put length check of array as nested within existance check.</b></table>
